### PR TITLE
Update mapspawn.nut

### DIFF
--- a/scripts/vscripts/mapspawn.nut
+++ b/scripts/vscripts/mapspawn.nut
@@ -1,77 +1,176 @@
-local objRes = Entities.FindByClassname(null, "tf_objective_resource")
-local delay = 1 //delay the popfile name switch incase the mission itself changes it first
+// Script is executed by the game every map spawn.
+::__potato <- {
+    // Seconds to delay formatting the mission display name.
+    FormatNameDelay = 1.0
 
-local diffKeywords = {
-    int = "(Int)" //was gonna format these in, but it's better to just use the pivot
-    adv = "(Adv)"
-    exp = "(Exp)"
-}
+    objective_resource = null
+    mapname = GetMapName()
+    len_mapname = GetMapName().len()
+    // True if the server is running the sigsegv-mvm extension.
+    IsSigmod = Convars.GetInt("sig_color_console") != null ? true : false
 
-local pivotKeywords = {
-    rev = null
-    reverse = null
-    final = null
-}
-
-
-::__NameFormat <- {
-
-    function IsSigmod() { return Convars.GetStr("sig_color_console") != null ? true : false }
-
-    function Format()
-    {
-        local popname = NetProps.GetPropString(objRes, "m_iszMvMPopfileName")
-        local str = ""
-        local s = []
-        local pivot = -1
-
-        if (startswith(popname, "scripts/population/") && endswith(popname, ".pop")) //probably an unmodified name
-            s = split(split(popname, "/")[2], "_")
-
-        local len = s.len() - 1
-
-        //first clean up the array
-        for (local i = len; i >= 0; i--)
-        {
-            local name = s[i]
-
-            //remove "mvm" and remove rev if there's already a difficulty keyword
-            if (name == "mvm" || (name == "rev" && (s[i - 1] in diffKeywords || s[i + 1] in diffKeywords)))
-            {
-                s.remove(i)
-                continue
-            }
-
-            //remove .pop suffix
-            if (i == len)
-            {
-                s[i] = split(name, ".")[0]
-                continue
-            }
-        }
-
-        //find a pivot keyword to separate map and mission name.
-        foreach(i, name in s)
-        {
-            local namelen = name.len()
-            if (name in diffKeywords || name in pivotKeywords || (startswith(name, "rc") && namelen < 5) || (startswith(name, "b") && namelen < 4) || (startswith(name, "a") && namelen < 4))
-                pivot = i+1
-        }
-
-        if (pivot == -1) return
-
-        str += format("(%s) ", s[pivot - 1])
-
-        for (local i = pivot; i < s.len(); i++)
-            str += format("%s ", s[i])
-
-        //setting this netprop directly will break the map rotation for rafmod/sigmod servers, use ClientProp instead to fake it
-        this.IsSigmod() ? EntFireByHandle(objRes, "$SetClientProp$m_iszMvMPopfileName", format("%s", str), -1, null, null) : EntFireByHandle(objRes, "RunScriptCode", format("NetProps.SetPropString(self, `m_iszMvMPopfileName`, `%s`)", str), -1, null, null)
+    // Mapping for difficulty phrases to respective display name.
+    difficultyMap = {
+        "nor": "(Nor) "
+        "int": "(Int) "
+        "adv": "(Adv) "
+        "exp": "(Exp) "
     }
+    // Phrases to ignore when formatting mission display name.
+    toStrip = [
+        "rev",
+        "reverse"
+    ]
+
+    /**
+     * Sets the current mission display name according to Potato.tf standard formatting, if
+     * the mission name is otherwise unchanged.
+     * Standard format is "(Difficulty) Mission Name".
+     *
+     * @param str popname   Mission name to format.
+     * @param bool end      Set to true to use end card formatting (no difficulty).
+     */
+    function SetMissionName(popname, end = false) {
+        if (startswith(popname, "scripts/population/mvm_") && endswith(popname, ".pop")) {
+            // Split:
+            //  "scripts/population/mvm_condemned_b3_adv_unholy_undead.pop"
+            // To:
+            //  ["adv", "unholy", "undead"]
+            local strings = split(popname.slice(20 + __potato.len_mapname, -4), "_")
+
+            local name = ""  // Mission display name
+            local difficulty = ""   // Mission dispaly difficulty tag
+            for(local i = 0; i <= strings.len() - 2; ++i) {
+                // Don't include "rev" or "reverse" in formatted version
+                if (strings[i] in this.toStrip) continue
+                // Test for mission difficulty tag
+                //  No way to access a key without potentially throwing an exception,
+                //   and exceptions aren't typed so have to do this (or use arrays instead
+                //   of a table for __potato.difficultyMap)
+                if (strings[i] in this.difficultyMap) {
+                    difficulty = this.difficultyMap[strings[i]]
+                    continue
+                }
+                // Join strings to form mission name with space separator
+                name += strings[i] + " "
+            }
+            // Add mission difficulty to the start if it exists.
+            //  Don't add if on the victory screen since map name will also be squashed in.
+            // Also append the last word of the mission name, done outside the loop to avoid
+            //  a trailing space.
+            if (end == false) {
+                name = difficulty + name + strings.top()
+            } else {
+                name = name + strings.top()
+            }
+
+            if (this.IsSigmod) {
+                // Use $SetClientProp if on a sigsegv-mvm server
+                //  This is done because the Potato plugin that intercepts the default mission
+                //  cycle behaviour retrieves the popfile name directly from this NetProp,
+                //  which causes the plugin to fail if we have overwritten the default string
+                //  name. Plugin authors should consider using a method like this instead:
+                //  https://github.com/mtxfellen/tf2-plugins/blob/3a83742/addons/sourcemod/scripting/include/tfmvm_stocks.inc#L21
+                EntFireByHandle(__potato.objective_resource, "$SetClientProp$m_iszMvMPopfileName", format("%s", name), -1, null, null)
+            } else {
+                // Otherwise write the formatted mission name directly to the prop.
+                NetProps.SetPropString(__potato.objective_resource, "m_iszMvMPopfileName", name)
+            }
+        }
+    }
+
+    /**
+     * Applies the map fixes specified for the current map.
+     */
+    function ApplyMapFixes() {
+        switch (__potato.mapname) {
+            // Oilrig
+            case "mvm_oilrig_rc5a":
+                // Rain particles fix - replace missing rain particles with sawmill rain.
+                // Kill broken rain particles
+                for (local particlesystem; particlesystem = Entities.FindByClassname(particlesystem, "info_particle_system");) {
+                    if (particlesystem.GetName() == "end_pit_destroy_particle") continue
+                    // Kill() and Destroy() methods will cause this to iterate ~300 times,
+                    //  so must EntFire() instead
+                    EntFireByHandle(particlesystem, "Kill", "", 0, null, null)
+                }
+
+                // Spawn replacement rain; looks bad if we just use the position of the old particle systems
+                local rain2 = [Vector(-508, -2608, 1800), Vector(789, -2290, 1800), Vector(-324, -2694, 1800), Vector(-320, -3360, 1800)]
+                local rain = [Vector(-2848, 384, 8810), Vector(-1200, 1924, 3620),
+                    Vector(282, 1924, 3620), Vector(882, 1924, 3620), Vector(-366, -608, 3620), Vector(528, -608, 4100),
+                    Vector(1849, -291, 3420), Vector(0, -1000, 1600), Vector(1024, -1632, 4100), Vector(-1024, -1632, 4100),
+                    Vector(1562, -2210, 3620), Vector(-864, -3936, 3620), Vector(160, -4096, 4200), Vector(320, -4960, 4300),
+                    Vector(-704, -4960, 4300), Vector(1242, -4256, 3620), Vector(-1146, -4702, 3620)]
+                foreach(vec in rain2) {
+                    SpawnEntityFromTable("info_particle_system", {
+                        origin = vec
+                        effect_name = "env_rain_002_256"
+                        start_active = 1
+                        flag_as_weather = 1
+                    })
+                }
+                foreach(vec in rain) {
+                    SpawnEntityFromTable("info_particle_system", {
+                        origin = vec
+                        effect_name = "env_rain_001"
+                        start_active = 1
+                        flag_as_weather = 1
+                    })
+                }
+
+                // Tank spawn fixes
+                // Add missing func_respawnroom to tank spawn.
+                local tankspawn = SpawnEntityFromTable("func_respawnroom", {
+                    origin = Vector(-520, -5450, 1063)
+                    TeamNum = Constants.ETFTeam.TF_TEAM_BLUE
+                })
+                // Some properties are reset when spawn is dispatched, so they must be set
+                //  post-spawn.
+                tankspawn.SetSize(Vector(), Vector(400, 410, 200))
+                tankspawn.SetSolid(Constants.ESolidType.SOLID_BBOX)
+                // Mark tank spawn nav to properly provide bot uber.
+                local tanknav = NavMesh.GetNavAreaByID(27)
+                tanknav.SetAttributeTF(Constants.FTFNavAttributeType.TF_NAV_SPAWN_ROOM_BLUE)
+                tanknav.ClearAttributeTF(Constants.FTFNavAttributeType.TF_NAV_BOMB_CAN_DROP_HERE)
+
+                // Collect dropped cash in tank spawn.
+                local tankcollect = SpawnEntityFromTable("trigger_hurt", {
+                    origin = Vector(-520, -5450, 1063)
+                })
+                tankcollect.SetSize(Vector(), Vector(400, 410, 200))
+                tankcollect.SetSolid(Constants.ESolidType.SOLID_BBOX)
+                break
+
+            // Rottenburg
+            case "mvm_rottenburg":
+                // Fix tank barricade turning invisible
+                EntFire("Barricade", "SetParent", "Tank_Barricade_Particle")
+                // Fix bad collision on tank barricade
+                EntFire("Barricade", "DisableCollision")
+                break
+        }
+    }
+
     Events = {
+        // Event is fired every wave init (on mission change, wave jump or post wave fail).
         function OnGameEvent_teamplay_round_start(_) {
-            EntFire("worldspawn", "RunScriptCode", "__NameFormat.Format()", delay)
+            __potato.ApplyMapFixes()
+
+            // tf_objective_resource is made by tf_gamerules after map init, so we can't fetch it on map spawn.
+            __potato.objective_resource = Entities.FindByClassname(null, "tf_objective_resource")
+
+            // We want to delay setting the mission display name so that mission makers may
+            //  set their own as desired.
+            EntFire("worldspawn", "RunScriptCode", @"
+                __potato.SetMissionName(NetProps.GetPropString(__potato.objective_resource, ""m_iszMvMPopfileName""), false)"
+            , __potato.FormatNameDelay)
+        }
+        // Event is fired at mission victory (all waves complete).
+        function OnGameEvent_mvm_mission_complete(params) {
+            __potato.SetMissionName(params.mission, true)
         }
     }
 }
-__CollectGameEventCallbacks(__NameFormat.Events)
+
+__CollectGameEventCallbacks(__potato.Events)


### PR DESCRIPTION
- Mission Name Formatter
   - Now does something (previously attempted to fetch tf_objective_resource before it spawned).
   - Simplified logic; pivot system replaced by using GetMapName().
   - Removes difficulty from mission name when victory panel is shown (looks like [this](https://i.imgur.com/VdpANpu.png)).
- Added map fixes to mapspawn.nut.
   - Oilrig
       - Added missing tank spawn features.
       - Fixed missing rain particles.
   - Rottenburg
       - Tank barricade collision & visibility fix.
- Added some code comments.