### PR TITLE
Stuff for Patch 2

### DIFF
--- a/scripts/population/mvm_downpour_rc3a_adv_wet_wreckage.pop
+++ b/scripts/population/mvm_downpour_rc3a_adv_wet_wreckage.pop
@@ -445,7 +445,7 @@ population
 		"auto fires when full"			1
 		// "spread penalty"				2.2 //fucking atrocity
 		"fire rate penalty hidden"		0.66
-		"reload time increased hidden"	1.1	// 1.3
+		"reload time increased hidden"	1.2	// 1.1	// 1.3
 		Paintkit_proto_def_index		403
 		Set_item_texture_wear			0
 		"crit mod disabled"				0
@@ -548,46 +548,40 @@ population
 				ItemName	"Wild Revolver"
 			}
 		}
-
-		Wildrevolver_Special
-		{
-			Name		"High Noon"
-			Attribute	"killstreak tier"
-			Description	"Last shot always crits, damage increased by 35%."
-			Cap			2
-			Increment	2
-			Cost		650
-
-			AllowedWeapons
-			{
-				ItemName	"Wild Revolver"
-			}
-
-			SecondaryAttributes
-			{
-				"killstreak idleeffect"	2
-				"CARD: damage bonus"	0.35
-				"last shot crits"		1
-			}
-
-			RequiredUpgrade
-			{
-				Upgrade	Wildrevolver_Damage
-				Level	4
-			}
-
-			OnApply
-			{
-				OutPut	"!activator,$giveitem,Texas Ten Gallon,0,0"
-			}
-
-			OnUpgrade
-			{
-				Output	!activator,$playsoundtoself,weapons/saxxy_impact_gen_06.wav,0
-				Output	!activator,speakresponseconcept,TLK_MVM_LOOT_RARE,1.5
-				OutPut	"!activator,$giveitem,Texas Ten Gallon,0,0"
-			}
-		}
+		// Wildrevolver_Special
+		// {
+		// Name		"High Noon"
+		// Attribute	"killstreak tier"
+		// Description	"Last shot always crits, damage increased by 35%."
+		// Cap			2
+		// Increment	2
+		// Cost		650
+		// AllowedWeapons
+		// {
+		// ItemName	"Wild Revolver"
+		// }
+		// SecondaryAttributes
+		// {
+		// "killstreak idleeffect"	2
+		// "CARD: damage bonus"	0.35
+		// "last shot crits"		1
+		// }
+		// RequiredUpgrade
+		// {
+		// Upgrade	Wildrevolver_Damage
+		// Level	4
+		// }
+		// OnApply
+		// {
+		// OutPut	"!activator,$giveitem,Texas Ten Gallon,0,0"
+		// }
+		// OnUpgrade
+		// {
+		// Output	!activator,$playsoundtoself,weapons/saxxy_impact_gen_06.wav,0
+		// Output	!activator,speakresponseconcept,TLK_MVM_LOOT_RARE,1.5
+		// OutPut	"!activator,$giveitem,Texas Ten Gallon,0,0"
+		// }
+		// }
 	}
 	// RAFMOD END
 	// WAVE 1 //////////CURRENCY 1100///////////////////////////////////

--- a/scripts/population/mvm_rottenburg_exp_germanium_gearbox.pop
+++ b/scripts/population/mvm_rottenburg_exp_germanium_gearbox.pop
@@ -2011,23 +2011,6 @@ population
 		}
 		WaveSpawn
 		{
-			Name	sup4.1
-			WaitForAllSpawned	4c3
-			TotalCount	9
-			MaxActive	9
-			SpawnCount	3
-			Where	flankers
-			WaitBeforeStarting	0
-			Waitbetweenspawns	5
-			Support 1
-			TFBot
-			{
-				Class	Scout
-				Skill	Easy
-			}
-		}
-		WaveSpawn
-		{
 			Name	4c3
 			WaitForAllSpawned	4c2
 			TotalCurrency	25
@@ -2058,6 +2041,37 @@ population
 					CharacterAttributes
 					{
 						"move speed bonus"	1
+					}
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name	sup4.1
+			WaitForAllSpawned	4c3
+			TotalCount	9
+			MaxActive	9
+			SpawnCount	3
+			Where	flankers
+			WaitBeforeStarting	0
+			Waitbetweenspawns	5
+			Support 1
+			RandomChoice
+			{
+				TFBot
+				{
+					Class	Scout
+					Skill	Easy
+				}
+				TFBot
+				{
+					Class	Pyro
+					Skill	Hard
+					Item	"Upgradeable TF_WEAPON_FLAMETHROWER"
+					ItemAttributes
+					{
+						Itemname	"Upgradeable TF_WEAPON_FLAMETHROWER"
+						"airblast disabled"	1
 					}
 				}
 			}
@@ -2539,6 +2553,13 @@ population
 					Template	T_TFBot_Giant_Medic
 					Attributes	IgnoreEnemies
 					Classicon	medic_pop_giant
+					Item		"Platinum Pickelhaube"
+					Item		"Coldfront Carapace"
+					ItemAttributes
+					{
+						Itemname	"Platinum Pickelhaube"
+						"set item tint rgb"		15132390	//	An Abundance of Tinge
+					}
 					CharacterAttributes
 					{
 						"move speed bonus"	1
@@ -2585,7 +2606,7 @@ population
 		WaveSpawn
 		{
 			Name	6b
-			TotalCurrency	100
+			TotalCurrency	50
 			TotalCount	15
 			MaxActive	10
 			SpawnCount	1
@@ -2605,6 +2626,37 @@ population
 				CharacterAttributes
 				{
 					"increase buff duration"	9.0
+				}
+			}
+		}
+		WaveSpawn
+		{
+			Name	6b2
+			TotalCurrency	50
+			TotalCount	12
+			MaxActive	6
+			SpawnCount	2
+			Where	flankers
+			WaitBeforeStarting	8
+			Waitbetweenspawns	4
+			TFBot
+			{
+				Class		Pyro
+				Skill		Hard
+				Name		"Backburner Pyro"
+				Classicon	pyro_backburner_nys
+				Attributes	AlwaysFireWeapon
+				Item		"The Backburner"
+				Item		"The Rusty Reaper"
+				ItemAttributes
+				{
+					ItemName	"The Rusty Reaper"
+					"set item tint rgb"		15185211	//	Australium Gold
+				}
+				ItemAttributes
+				{
+					Itemname	"The Backburner"
+					"lunchbox adds minicrits"	2
 				}
 			}
 		}
@@ -2941,14 +2993,23 @@ population
 			Waitbetweenspawns	5
 			TFBot
 			{
-				Class	Pyro
-				Skill	Normal
-				MaxVisionRange 1000
-				Name	"Dragon Fury Pyro"
-				Item	"The Dragon's Fury"
-				Item	"Pyromancer's Mask"
-				ClassIcon	pyro_dragon_fury_swordstone
-				Attributes	AlwaysCrit
+				Class		Pyro
+				Skill		Hard
+				Name		"Backburner Pyro"
+				Classicon	pyro_backburner_nys
+				Attributes	AlwaysFireWeapon
+				Item		"The Backburner"
+				Item		"The Rusty Reaper"
+				ItemAttributes
+				{
+					ItemName	"The Rusty Reaper"
+					"set item tint rgb"		15185211	//	Australium Gold
+				}
+				ItemAttributes
+				{
+					Itemname	"The Backburner"
+					"lunchbox adds minicrits"	2
+				}
 			}
 		}
 		WaveSpawn
@@ -3023,14 +3084,12 @@ population
 		{
 			Name	Mission_end__voice_relay_6.1
 			WaitForAllDead		6e
-			WaitBeforeStarting	2
 			FirstSpawnWarningSound	"ui\itemcrate_smash_ultrarare_fireworks.wav"	//	Australium unbox fireworks sound
 		}
 		WaveSpawn
 		{
 			Name	Mission_end__voice_relay_6.1
 			WaitForAllDead		6e
-			WaitBeforeStarting	2
 			FirstSpawnWarningSound	"ui\itemcrate_smash_ultrarare_fireworks.wav"	//	Australium unbox fireworks sound
 		}
 	}

--- a/scripts/population/mvm_scallops_rc4a_exp_what_the_scallop.pop
+++ b/scripts/population/mvm_scallops_rc4a_exp_what_the_scallop.pop
@@ -404,6 +404,7 @@ population
 				EntFire(`placeholder_relay_killer_disable_all`, `Trigger`)
 				EntFire(`spawnbot_placeholder4`, `Disable`)
 				EntFire(`gamerules`, `RunScriptFile`, `exp_pyro_spawner.nut`, 1)
+				EntFire(`tutorial_relay`, `Trigger`)
 			"
 		}
 		StartWaveOutput

--- a/scripts/population/robot_lyney.pop
+++ b/scripts/population/robot_lyney.pop
@@ -833,7 +833,7 @@ WaveSchedule
 			ItemAttributes
 			{
 				ItemName "The Quick-Fix"
-				"ubercharge rate bonus" 0.1
+				"ubercharge rate bonus" 0.01
 			}
 			ItemAttributes
 			{
@@ -1371,7 +1371,7 @@ WaveSchedule
 				ItemName "TF_WEAPON_ROCKETLAUNCHER"
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.5
-
+				"Projectile speed increased" 0.65
 			}
 		}
 		
@@ -2402,6 +2402,7 @@ WaveSchedule
 				ItemName "TF_WEAPON_ROCKETLAUNCHER"
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.5
+				"Projectile speed increased" 0.65
 			}
 		}
 		
@@ -2415,6 +2416,7 @@ WaveSchedule
 				ItemName "TF_WEAPON_ROCKETLAUNCHER"
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.5
+				"Projectile speed increased" 0.65
 			}
 		}
 		
@@ -2428,6 +2430,7 @@ WaveSchedule
 				ItemName "TF_WEAPON_ROCKETLAUNCHER"
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.5
+				"Projectile speed increased" 0.65
 			}
 		}
 		
@@ -2671,7 +2674,7 @@ WaveSchedule
 		T_TFBot_Giant_Soldier_Extended_Battalion_BurstFire_Spammer
 		{
 			Template T_TFBot_Giant_Soldier_Extended_Battalion_Bugfixed
-			Name "Giant Rapid Burst Batts Soldier"
+			Name "Giant Rapid Burst Batt Soldier"
 			ClassIcon soldier_backup_burstfire_spammer_yoovy_giant
 			ItemAttributes
 			{
@@ -2766,6 +2769,7 @@ WaveSchedule
 				"damage bonus" 2.0
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.35
+				"Projectile speed increased" 0.65
 			}
 			CharacterAttributes
 			{
@@ -2773,7 +2777,6 @@ WaveSchedule
 				"damage force reduction" 0.4
 				"airblast vulnerability multiplier" 0.4
 				"override footstep sound set" 3
-				"Projectile speed increased" 0.65
 				"cancel falling damage" 1
 				"blast dmg to self increased" 0
 			}
@@ -2921,7 +2924,7 @@ WaveSchedule
 				ItemName "The Cow Mangler 5000"
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.5
-
+				"Projectile speed increased" 0.65
 			}
 			CharacterAttributes
 			{
@@ -2929,7 +2932,6 @@ WaveSchedule
 				"damage force reduction" 0.4
 				"airblast vulnerability multiplier" 0.4
 				"override footstep sound set" 3
-				"Projectile speed increased" 0.65
 				"cancel falling damage" 1
 				"blast dmg to self increased" 0
 			}
@@ -2951,6 +2953,7 @@ WaveSchedule
 				"faster reload rate" -0.8
 				"fire rate bonus" 0.3
 				"damage bonus" 2.0
+				"Projectile speed increased" 0.65
 			}
 			CharacterAttributes
 			{
@@ -2958,7 +2961,6 @@ WaveSchedule
 				"damage force reduction" 0.4
 				"airblast vulnerability multiplier" 0.4
 				"override footstep sound set" 3
-				"Projectile speed increased" 0.65
 				"cancel falling damage" 1
 				"blast dmg to self increased" 0
 			}
@@ -3098,6 +3100,7 @@ WaveSchedule
 				"fire rate bonus" 0.35
 				"dmg bonus vs buildings" 10
 				"dmg penalty vs players" 2
+				"Projectile speed increased" 0.65
 			}
 			CharacterAttributes
 			{


### PR DESCRIPTION
- Fix name formatter breaking on Valve pops.
- Mansion: Fixed bad spawnroom visualizer render depth.
- Germanium Gearbox: Added small pyros to W4&6, cosmetic changes to W6.
- Netherite Navy: Added slower projectiles to Rapid Banner GSoldiers.
- Wet Wreckage: Wild Revolver custom weapon nerf.
- What The Scallop: Fixed tutorial annotations not showing.