### PR TITLE
Download robosandvich icon fix

### DIFF
--- a/scripts/population/mvm_rottenburg_int_calendartillery.pop
+++ b/scripts/population/mvm_rottenburg_int_calendartillery.pop
@@ -1232,7 +1232,7 @@ WaveSchedule
 				// "arrow hit kill time" 0.1  
 				
 				"custom projectile model" "models/weapons/w_models/w_drg_ball.mdl"
-				// "custom kill icon" "annihilator"  
+				"custom kill icon" "annihilator" [$SIGSEGV]
 				"ragdolls plasma effect" 1
 			}
 			// Tag "popext_fireweapon" / changed to Tag, didn't modify below
@@ -2745,6 +2745,40 @@ PopExt.AddRobotTag(`sandvich`, {
 			TFBot
 			{
 				Template Summer_Pyro_Gas
+			}
+		}
+		
+		//Custom icons aren't downloaded unless they're on a bot in the wave. Even if the bot never spawns.
+		WaveSpawn
+		{
+			Name "The Laviscuous Luncher"
+			WaitForAllDead "Support"
+			Where spawnbot
+			TotalCount 1
+			MaxActive 1
+			SpawnCount 1
+			TotalCurrency 0
+			Support Limited
+			RandomChoice
+			{
+				RandomChoice
+				{
+					TFBot
+					{
+						Class Scout
+						Name "The Laviscuous Luncher"
+						Attributes IgnoreFlag
+						Attributes IgnoreEnemies
+						ClassIcon heavy_robosandvich_nys //makes the icon precache properly!
+						Health 5
+						Scale 0.1
+						CharacterAttributes
+						{
+							"move speed bonus" 0.01
+							"no_jump" 1
+						}
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For Calendartillery, heavy_robosandvich_nys would not be downloaded in the current state. Adding a dummy bot to wave 2 which never spawns and does not break the wave has fixed this.